### PR TITLE
Send tweets to all subscribers

### DIFF
--- a/twitter-streamer/app/actors/TwitterStreamer.scala
+++ b/twitter-streamer/app/actors/TwitterStreamer.scala
@@ -56,7 +56,7 @@ object TwitterStreamer {
 //						.runWith(Sink.actorRef(out, "Done"))
 						.runForeach { tweet =>
               Logger.info(tweet)
-              out ! tweet.trim
+              subscribers.foreach(_ ! tweet.trim)
 						}
     }
     


### PR DESCRIPTION
This allows all subscribers to receive the tweets as they come in. I think it didn't work before because your stream is static and you can only connect/pull from it once. So only the first websocket would be getting updates. Not 100% sure, but that's my theory. There's still probably a better way to do this.
